### PR TITLE
Fix user model query in registration endpoint

### DIFF
--- a/fayda_backend/app/api/endpoints/register.py
+++ b/fayda_backend/app/api/endpoints/register.py
@@ -3,12 +3,14 @@ from sqlalchemy.orm import Session
 from app.db.session import get_db
 from app.schemas.user import UserCreate, UserOut
 from app.crud import user as crud_user
+from app.models.user import User
 
 router = APIRouter()
 
 @router.post("/", response_model=UserOut)
 def register_user(user_in: UserCreate, db: Session = Depends(get_db)):
-    existing = db.query(crud_user.User).filter_by(email=user_in.email).first()
+    # BUGFIX: use User model instead of non-existent crud_user.User
+    existing = db.query(User).filter_by(email=user_in.email).first()
     if existing:
         raise HTTPException(status_code=400, detail="Email already registered")
     return crud_user.create_user(db, user_in)


### PR DESCRIPTION
## Summary
- fix register endpoint to query User model directly

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403)*
- `python -m flake8 .` *(fails: No module named flake8)*

------
https://chatgpt.com/codex/tasks/task_e_683f4e1de5e483208165641b93b55621