### PR TITLE
Fix import and remove stray comment

### DIFF
--- a/fayda_backend/app/api/endpoints/user.py
+++ b/fayda_backend/app/api/endpoints/user.py
@@ -1,15 +1,19 @@
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from sqlalchemy.orm import Session
 from app.models.user import User
-from app.schemas.user import UserBase, UserUpdate, UserPasswordUpdate, UserOut
-rBase, UserUpdate, UserPasswordUpdate
+from app.schemas.user import (
+    UserBase,
+    UserUpdate,
+    UserPasswordUpdate,
+    UserOut,
+)
 from app.core.security import (
     get_password_hash,
     verify_password,
     get_current_user,
 )
 from app.db.session import get_db
-from app.models.payment import Payment  # Import Payment model!
+from app.models.payment import Payment
 from app.schemas.payment import PaymentOut
 import shutil, os
 


### PR DESCRIPTION
## Summary
- fix stray comment in user endpoint import block
- compiled Python sources and ran lint/tests

## Testing
- `find fayda_backend/app -name '*.py' | xargs python3 -m py_compile`
- `cd fayda_backend && flake8 . && cd ..`
- `cd fayda_frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841cfbffc3c8320a7132ed24936b382