### PR TITLE
Fix table initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ git clone https://github.com/mesfinyerga/fayda-id-checker.git
 cd fayda-id-checker
 
 # Backend Setup
-cd backend
+cd fayda_backend
 python -m venv venv
 source venv/bin/activate  # or venv\Scripts\activate on Windows
 pip install -r requirements.txt
-uvicorn main:app --reload #uvicorn app.main:app --reload 
+python -m app.db.init_db  # create the SQLite database tables
+uvicorn main:app --reload #uvicorn app.main:app --reload
 
 # Frontend Setup
 cd ../frontend

--- a/fayda_backend/app/db/base.py
+++ b/fayda_backend/app/db/base.py
@@ -1,7 +1,10 @@
+"""Database model registry."""
+
+from app.db.base_class import Base
 from app.models.user import User
 from app.models.payment import Payment
-# from sqlalchemy.ext.declarative import declarative_base
-# Base = declarative_base()
-from sqlalchemy.orm import declarative_base
 
-Base = declarative_base()
+# Importing the models above ensures they are registered on the shared ``Base``
+# metadata. ``Base`` itself is defined in :mod:`app.db.base_class` and must be
+# used consistently across the application so that table creation with
+# ``Base.metadata.create_all`` works as expected.


### PR DESCRIPTION
## Summary
- use shared base for model registry
- document database initialization in README

## Testing
- `flake8` *(fails: command not found)*
- `python -m app.db.init_db` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6841e18ec5b88320bcae11c00eb2b72a