### PR TITLE
Fix token handling in React frontend

### DIFF
--- a/fayda_frontend/src/components/AvatarUpload.jsx
+++ b/fayda_frontend/src/components/AvatarUpload.jsx
@@ -1,10 +1,8 @@
 import React, { useRef, useState } from "react";
 import { Button, CircularProgress } from "@mui/material";
-import { useAuth } from "../context/AuthContext";
-import axios from "axios";
+import api from "../utils/api";
 
 export default function AvatarUpload({ setProfile }) {
-  const { token } = useAuth();
   const [loading, setLoading] = useState(false);
   const inputRef = useRef();
 
@@ -15,8 +13,8 @@ export default function AvatarUpload({ setProfile }) {
     const formData = new FormData();
     formData.append("file", file);
     try {
-      const res = await axios.post("http://localhost:8000/users/me/avatar", formData, {
-        headers: { Authorization: `Bearer ${token}` }
+      const res = await api.post("/users/me/avatar", formData, {
+        headers: { 'Content-Type': 'multipart/form-data' }
       });
       setProfile((p) => ({ ...p, avatar_url: res.data.avatar_url }));
     } finally {

--- a/fayda_frontend/src/components/IDCheckForm.jsx
+++ b/fayda_frontend/src/components/IDCheckForm.jsx
@@ -16,11 +16,10 @@ import {
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import PermIdentityIcon from '@mui/icons-material/PermIdentity';
-import axios from 'axios';
-import { useAuth } from '../context/AuthContext';
+import api from '../utils/api';
+
 
 const IDCheckForm = () => {
-  const { token } = useAuth();
   const [idNumber, setIdNumber] = useState('');
   const [result, setResult] = useState(null);
   const [error, setError] = useState('');
@@ -34,14 +33,8 @@ const IDCheckForm = () => {
     setLoading(true);
 
     try {
-      console.log("🔑 Token sent to backend:", token);
-      const res = await axios.get(
-        `http://localhost:8000/id/mock-id-check/${idNumber}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
+      const res = await api.get(
+        `/id/mock-id-check/${idNumber}`
       );
       setResult(res.data);
     } catch (err) {

--- a/fayda_frontend/src/components/LoginForm.jsx
+++ b/fayda_frontend/src/components/LoginForm.jsx
@@ -4,7 +4,7 @@ import {
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import axios from 'axios';
+import api from '../utils/api';
 
 // Helper: Parse JWT and extract payload
 function parseJwt(token) {
@@ -36,7 +36,7 @@ const LoginForm = () => {
       formData.append('username', email);
       formData.append('password', password);
 
-      const res = await axios.post('http://localhost:8000/auth/login', formData, {
+      const res = await api.post('/auth/login', formData, {
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
       });
 

--- a/fayda_frontend/src/components/PaymentHistory.jsx
+++ b/fayda_frontend/src/components/PaymentHistory.jsx
@@ -21,8 +21,10 @@ import * as XLSX from "xlsx";
 import jsPDF from "jspdf";
 import "jspdf-autotable";
 import autoTable from "jspdf-autotable";
+import api from "../utils/api";
+import { useAuth } from "../context/AuthContext";
 
-const PAYMENT_ENDPOINT = "http://localhost:8000/payments/";
+const PAYMENT_ENDPOINT = "/payments/";
 
 const statusColors = {
   success: "#388e3c",
@@ -30,7 +32,8 @@ const statusColors = {
   pending: "#fbc02d",
 };
 
-export default function PaymentHistory({ token }) {
+export default function PaymentHistory() {
+  const { token } = useAuth();
   const [history, setHistory] = useState([]);
   const [loading, setLoading] = useState(true);
   const [methodFilter, setMethodFilter] = useState("");
@@ -40,11 +43,9 @@ export default function PaymentHistory({ token }) {
   useEffect(() => {
     if (!token) return;
     setLoading(true);
-    fetch(PAYMENT_ENDPOINT, {
-      headers: { Authorization: `Bearer ${token}` }
-    })
-      .then(res => res.ok ? res.json() : [])
-      .then(data => setHistory(data))
+    api
+      .get(PAYMENT_ENDPOINT)
+      .then((res) => setHistory(res.data))
       .catch(() => setHistory([]))
       .finally(() => setLoading(false));
   }, [token]);

--- a/fayda_frontend/src/components/RegisterClientModal.jsx
+++ b/fayda_frontend/src/components/RegisterClientModal.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import api from '../utils/api';
 import {
   Dialog, DialogTitle, DialogContent, DialogActions,
   TextField, MenuItem, Button, Grid
@@ -32,19 +33,14 @@ const RegisterClientModal = ({ open, onClose, refreshUsers }) => {
     });
 
     try {
-      const res = await fetch("http://localhost:8000/register/", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
+      const res = await api.post("/register/", payload);
 
-      if (res.ok) {
+      if (res.status === 200 || res.status === 201) {
         alert("✅ Client registered successfully");
         onClose();
         if (refreshUsers) refreshUsers();
       } else {
-        const error = await res.json();
-        alert("❌ Error: " + (error.detail || "Registration failed"));
+        alert("❌ Registration failed");
       }
     } catch (err) {
       alert("❌ Network error: " + err.message);

--- a/fayda_frontend/src/pages/Payment.jsx
+++ b/fayda_frontend/src/pages/Payment.jsx
@@ -1,12 +1,10 @@
 import React, { useState } from "react";
-import axios from "axios";
+import api from "../utils/api";
 import { Container, Paper, Typography, TextField, Select, MenuItem, Button, Box, CircularProgress, Alert } from "@mui/material";
-import { useAuth } from "../context/AuthContext";
 
-const PAYMENT_ENDPOINT = "http://localhost:8000/payments/";
+const PAYMENT_ENDPOINT = "/payments/";
 
 export default function Payment() {
-  const { token } = useAuth();
   const [amount, setAmount] = useState("");
   const [method, setMethod] = useState("Telebirr");
   const [loading, setLoading] = useState(false);
@@ -19,10 +17,10 @@ export default function Payment() {
     setError("");
     setResult(null);
     try {
-      const response = await axios.post(
+      const response = await api.post(
         PAYMENT_ENDPOINT,
         { amount: parseFloat(amount), method },
-        { headers: { Authorization: `Bearer ${token}` } }
+        {}
       );
       setResult(response.data);
     } catch (err) {

--- a/fayda_frontend/src/pages/UserDashboard.jsx
+++ b/fayda_frontend/src/pages/UserDashboard.jsx
@@ -69,7 +69,7 @@ const UserDashboard = () => {
       </Paper>
 
       {/* Payment History Section */}
-      <PaymentHistory token={token} />
+      <PaymentHistory />
     </Container>
   );
 };

--- a/fayda_frontend/src/pages/UserProfile.jsx
+++ b/fayda_frontend/src/pages/UserProfile.jsx
@@ -275,7 +275,7 @@ export default function UserProfile() {
         <Typography variant="h5" fontWeight="bold" gutterBottom>
           Payment & Subscription History
         </Typography>
-        <PaymentHistory token={token} />
+        <PaymentHistory />
       </Paper>
     </Container>
   );


### PR DESCRIPTION
## Summary
- use api wrapper in payment history
- remove token prop from pages
- refactor RegisterClientModal to use api wrapper

## Testing
- `npm run lint` *(fails: no-unused-vars and other lint errors)*
- `python -m flake8 fayda_backend/app` *(fails with style violations)*


------
https://chatgpt.com/codex/tasks/task_e_6843d8f28abc83208ac04167fb921918